### PR TITLE
Latest + Versioned releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,34 +1,25 @@
 name: Module CI/CD
 
-on: [push]
+on: 
+  push:
+    branches:
+      - master
 
-jobs:
+jobs: 
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 
     # create a zip file with all files required by the module to add to the release
-    - run: zip -r ./module.zip module.json styles/ scripts/ templates/ languages/
+    - name: Zip Files
+      run: zip -r ./module.zip ./*
 
     # Get the version from 'module.json'
     - name: Get Version
       shell: bash
       id: get-version
       run: echo "::set-output name=version::$(node ./.github/workflows/get-version.js)"
-
-    # Create a release for this specific version
-    - name: Create Release
-      id: create_version_release
-      uses: ncipollo/release-action@v1
-      with:
-        allowUpdates: true # set this to false if you want to prevent updating existing releases
-        name: Release ${{ steps.get-version.outputs.version }}
-        draft: false
-        prerelease: false
-        token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: './module.json,./module.zip'
-        tag: ${{ steps.get-version.outputs.version }}
 
     # Update the 'latest' release
     - name: Create Release
@@ -41,5 +32,28 @@ jobs:
         draft: false
         prerelease: false
         token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: './module.json,./module.zip'
+        artifacts: './module.json, ./module.zip'
         tag: latest
+
+    #Substitute the Manifest and Download URLs in the module.json
+    - name: Substitute Manifest and Download Links For Versioned Ones
+      id: sub_manifest_link
+      uses: microsoft/variable-substitution@v1
+      with:
+        files: 'module.json'
+      env:
+        manifest: https://github.com/$GITHUB_REPOSITORY/releases/download/${{steps.get-version.outputs.version}}/module.json
+        download: https://github.com/$GITHUB_REPOSITORY/releases/download/${{steps.get-version.outputs.version}}/module.zip
+    
+    # Create a release for this specific version
+    - name: Create Release
+      id: create_version_release
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: true # set this to false if you want to prevent updating existing releases
+        name: Release ${{ steps.get-version.outputs.version }}
+        draft: false
+        prerelease: false
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: './module.json,./module.zip'
+        tag: ${{ steps.get-version.outputs.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,8 @@ jobs:
       with:
         files: 'module.json'
       env:
-        manifest: https://github.com/${{GITHUB_REPOSITORY}}/releases/latest/download/module.json
-        download: https://github.com/${{GITHUB_REPOSITORY}}/releases/latest/download/module.zip
+        manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
+        download: https://github.com/${{github.repository}}/releases/latest/download/module.zip
 
     # Update the 'latest' release
     - name: Create Release
@@ -52,8 +52,8 @@ jobs:
       with:
         files: 'module.json'
       env:
-        manifest: https://github.com/${{GITHUB_REPOSITORY}}/releases/download/${{steps.get-version.outputs.version}}/module.json
-        download: https://github.com/${{GITHUB_REPOSITORY}}/releases/download/${{steps.get-version.outputs.version}}/module.zip
+        manifest: https://github.com/${{github.repository}}/releases/download/${{steps.get-version.outputs.version}}/module.json
+        download: https://github.com/${{github.repository}}/releases/download/${{steps.get-version.outputs.version}}/module.zip
     
     # Create a release for this specific version
     - name: Create Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
 
     #Useful only for the template so we can leave the manifest and download urls empty
     - name: Substitute Manifest and Download Links For Versioned Ones
-      id: sub_manifest_link
+      id: sub_manifest_link_latest
       uses: microsoft/variable-substitution@v1
       with:
         files: 'module.json'
@@ -47,7 +47,7 @@ jobs:
 
     #Substitute the Manifest and Download URLs in the module.json
     - name: Substitute Manifest and Download Links For Versioned Ones
-      id: sub_manifest_link
+      id: sub_manifest_link_version
       uses: microsoft/variable-substitution@v1
       with:
         files: 'module.json'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,8 @@ jobs:
       with:
         files: 'module.json'
       env:
-        manifest: https://github.com/$GITHUB_REPOSITORY/releases/latest/download/module.json
-        download: https://github.com/$GITHUB_REPOSITORY/releases/latest/download/module.zip
+        manifest: https://github.com/${{GITHUB_REPOSITORY}}/releases/latest/download/module.json
+        download: https://github.com/${{GITHUB_REPOSITORY}}/releases/latest/download/module.zip
 
     # Update the 'latest' release
     - name: Create Release
@@ -52,8 +52,8 @@ jobs:
       with:
         files: 'module.json'
       env:
-        manifest: https://github.com/$GITHUB_REPOSITORY/releases/download/${{steps.get-version.outputs.version}}/module.json
-        download: https://github.com/$GITHUB_REPOSITORY/releases/download/${{steps.get-version.outputs.version}}/module.zip
+        manifest: https://github.com/${{GITHUB_REPOSITORY}}/releases/download/${{steps.get-version.outputs.version}}/module.json
+        download: https://github.com/${{GITHUB_REPOSITORY}}/releases/download/${{steps.get-version.outputs.version}}/module.zip
     
     # Create a release for this specific version
     - name: Create Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,16 @@ jobs:
       id: get-version
       run: echo "::set-output name=version::$(node ./.github/workflows/get-version.js)"
 
+    #Useful only for the template so we can leave the manifest and download urls empty
+    - name: Substitute Manifest and Download Links For Versioned Ones
+      id: sub_manifest_link
+      uses: microsoft/variable-substitution@v1
+      with:
+        files: 'module.json'
+      env:
+        manifest: https://github.com/$GITHUB_REPOSITORY/releases/latest/download/module.json
+        download: https://github.com/$GITHUB_REPOSITORY/releases/latest/download/module.zip
+
     # Update the 'latest' release
     - name: Create Release
       id: create_latest_release

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "module",
   "title": "New Module",
   "description": "",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "minimumCoreVersion": "0.6.2",
   "compatibleCoreVersion": "0.7.2",
   "author": "Cody Swendrowski <cody@swendrowski.us>",

--- a/module.json
+++ b/module.json
@@ -26,6 +26,6 @@
     }
   ],
   "url": "https://github.com/cswendrowski/FoundryVTT-module",
-  "manifest": "https://github.com/cswendrowski/FoundryVTT-module/releases/download/latest/module.json",
-  "download": "https://github.com/cswendrowski/FoundryVTT-module/releases/download/0.0.1/module.zip"
+  "manifest": "",
+  "download": ""
 }


### PR DESCRIPTION
This will 
1) Only create releases on push to master
2) Create both a latest and a versioned release. Most people should use the latest release, BUT if someone wanted to point to a specific version locked release that didn't update due to compatibility, it will have that release there as well.

