### PR TITLE
change github action to be based on release

### DIFF
--- a/.github/workflows/get-version.js
+++ b/.github/workflows/get-version.js
@@ -1,2 +1,0 @@
-var fs = require('fs');
-console.log(JSON.parse(fs.readFileSync('module.json', 'utf8')).version);

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
-name: Module CI/CD
+name: Release Creation
 
-on: [push]
+on: 
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -8,27 +10,32 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    #Substitute the Manifest and Download URLs in the module.json
+    - name: Substitute Manifest and Download Links For Versioned Ones
+      id: sub_manifest_link_version
+      uses: microsoft/variable-substitution@v1
+      with:
+        files: 'module.json'
+      env:
+        version: ${{github.event.release.tag_name}}
+        manifest: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json
+        download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
+
     # create a zip file with all files required by the module to add to the release
     - run: zip -r ./module.zip module.json styles/ scripts/ templates/ languages/
 
-    # Get the version from 'module.json'
-    - name: Get Version
-      shell: bash
-      id: get-version
-      run: echo "::set-output name=version::$(node ./.github/workflows/get-version.js)"
-
     # Create a release for this specific version
-    - name: Create Release
+    - name: Update Release with Files
       id: create_version_release
       uses: ncipollo/release-action@v1
       with:
         allowUpdates: true # set this to false if you want to prevent updating existing releases
-        name: Release ${{ steps.get-version.outputs.version }}
+        name: Release ${{ github.event.release.tag_name }}
         draft: false
         prerelease: false
         token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: './module.json,./module.zip'
-        tag: ${{ steps.get-version.outputs.version }}
+        artifacts: './module.json, ./module.zip'
+        tag: ${{ github.event.release.tag_name }}
 
     # Update the 'latest' release
     - name: Create Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         artifacts: './module.json, ./module.zip'
         tag: ${{ github.event.release.tag_name }}
+        body: ${{ github.event.release.body }}
 
     # Update the 'latest' release
     - name: Create Release
@@ -50,3 +51,4 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         artifacts: './module.json,./module.zip'
         tag: latest
+        body: ${{ github.event.release.body }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       uses: ncipollo/release-action@v1
       with:
         allowUpdates: true # set this to false if you want to prevent updating existing releases
-        name: Release ${{ github.event.release.tag_name }}
+        name: ${{ github.event.release.name }}
         draft: false
         prerelease: false
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 
 4. Hit submit.
 
-The Release Title and Body will be overriden by the next step so hold off on filling those out.
+The Release Title will be overriden by the next step but you can take this opportunity to write in the release body.
 
-5. Wait a few minutes.
+1. Wait a few minutes.
 
 A Github Action will run to populate the `module.json` and `module.zip` with the correct urls that you can then use to distrubute this release. You can check on its status in the "Actions" tab.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 
 ![Draft a new release button.](https://user-images.githubusercontent.com/7644614/93409364-c1333c80-f864-11ea-89f1-abfcb18a8d9f.png)
 
-3. Fill out the release version.
+3. Fill out the release version as the tag name.
+
+## <span color="red">Do not prefix your tag name with a `v`.</span>
 
 If you want to add details at this stage you can, or you can always come back later and edit them.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,39 @@
 ![](https://img.shields.io/badge/Foundry-v0.7.2-informational)
 
+# How to use this Template to create a versioned Release
+
+1. Open your repository's releases page.
+
+![Where to click to open repository releases.](https://user-images.githubusercontent.com/7644614/93409301-9fd25080-f864-11ea-9e0c-bdd09e4418e4.png)
+
+2. Click "Draft a new release"
+
+![Draft a new release button.](https://user-images.githubusercontent.com/7644614/93409364-c1333c80-f864-11ea-89f1-abfcb18a8d9f.png)
+
+3. Fill out the release version.
+
+![Release Creation Form](https://user-images.githubusercontent.com/7644614/93409543-225b1000-f865-11ea-9a19-f1906a724421.png)
+
+4. Hit submit.
+
+The Release Title and Body will be overriden by the next step so hold off on filling those out.
+
+5. Wait a few minutes.
+
+A Github Action will run to populate the `module.json` and `module.zip` with the correct urls that you can then use to distrubute this release. You can check on its status in the "Actions" tab.
+
+![Actions Tab](https://user-images.githubusercontent.com/7644614/93409820-c1800780-f865-11ea-8c6b-c3792e35e0c8.png)
+
+6. Grab the module.json url from the release's details page.
+
+![image](https://user-images.githubusercontent.com/7644614/93409960-10c63800-f866-11ea-83f6-270cc5d10b71.png)
+
+This `module.json` will only ever point at this release's `module.zip`, making it useful for sharing a specific version for compatibility purposes.
+
 
 # FoundryVTT Module
 
 Does something, probably
-
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@
 
 3. Fill out the release version.
 
+If you want to add details at this stage you can, or you can always come back later and edit them.
+
 ![Release Creation Form](https://user-images.githubusercontent.com/7644614/93409543-225b1000-f865-11ea-9a19-f1906a724421.png)
 
 4. Hit submit.
 
-The Release Title will be overriden by the next step but you can take this opportunity to write in the release body.
-
-1. Wait a few minutes.
+5. Wait a few minutes.
 
 A Github Action will run to populate the `module.json` and `module.zip` with the correct urls that you can then use to distrubute this release. You can check on its status in the "Actions" tab.
 


### PR DESCRIPTION
A user might push frequently before desiring to release, during which time the old release's package may be updated several times with broken code.

Instead of creating or updating the latest release every time master is pushed to, it is less risky to only create a release package when a Github Release is published by the user.

Additionally, instead of relying on the user to have set the module.json version number correctly, we can use the tag they input to populate the module.json before it is zipped.

## Github Action

This does three things when a release is created:

1. Change module.json in three areas to point the module at this release:
  a. `version` -> the release tag number
  b. `manifest` -> this repository/releases/download/<this release>/module.json
  c. `download` -> this repository/releases/download/<this release>/module.zip

2. Zip up all relevant files from the repo into a zip.
  - relevant in this case is "All files within ./scripts and the module.json we just modified"

3. Update the release we just created by attaching that zip file. Also attach the modified `module.json`.

3. Update the "Latest" github release to this new tag.

See the [result in my forked repo](https://github.com/ElfFriend-DnD/FoundryVTT-Module-Template/releases/tag/24.1.13).