### PR TITLE
Remove unnecessary Latest release step, clarify README

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    #Substitute the Manifest and Download URLs in the module.json
+    # Substitute the Manifest and Download URLs in the module.json
     - name: Substitute Manifest and Download Links For Versioned Ones
       id: sub_manifest_link_version
       uses: microsoft/variable-substitution@v1
@@ -21,7 +21,7 @@ jobs:
         manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
         download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
 
-    # create a zip file with all files required by the module to add to the release
+    # Create a zip file with all files required by the module to add to the release
     - run: zip -r ./module.zip module.json styles/ scripts/ templates/ languages/
 
     # Create a release for this specific version
@@ -29,26 +29,11 @@ jobs:
       id: create_version_release
       uses: ncipollo/release-action@v1
       with:
-        allowUpdates: true # set this to false if you want to prevent updating existing releases
+        allowUpdates: true # Set this to false if you want to prevent updating existing releases
         name: ${{ github.event.release.name }}
         draft: false
         prerelease: false
         token: ${{ secrets.GITHUB_TOKEN }}
         artifacts: './module.json, ./module.zip'
         tag: ${{ github.event.release.tag_name }}
-        body: ${{ github.event.release.body }}
-
-    # Update the 'latest' release
-    - name: Create Release
-      id: create_latest_release
-      uses: ncipollo/release-action@v1
-      if: endsWith(github.ref, 'master')
-      with:
-        allowUpdates: true
-        name: Latest
-        draft: false
-        prerelease: false
-        token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: './module.json,./module.zip'
-        tag: latest
         body: ${{ github.event.release.body }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you want to add details at this stage you can, or you can always come back la
 
 5. Wait a few minutes.
 
-A Github Action will run to populate the `module.json` and `module.zip` with the correct urls that you can then use to distrubute this release. You can check on its status in the "Actions" tab.
+A Github Action will run to populate the `module.json` and `module.zip` with the correct urls that you can then use to distribute this release. You can check on its status in the "Actions" tab.
 
 ![Actions Tab](https://user-images.githubusercontent.com/7644614/93409820-c1800780-f865-11ea-8c6b-c3792e35e0c8.png)
 
@@ -31,6 +31,10 @@ A Github Action will run to populate the `module.json` and `module.zip` with the
 ![image](https://user-images.githubusercontent.com/7644614/93409960-10c63800-f866-11ea-83f6-270cc5d10b71.png)
 
 This `module.json` will only ever point at this release's `module.zip`, making it useful for sharing a specific version for compatibility purposes.
+
+7. You can use the url `https://github.com/<user>/<repo>/releases/latest/download/module.json` to refer to the manifest.
+
+This is the url you want to use to install the module typically, as it will get updated automatically.
 
 
 # FoundryVTT Module


### PR DESCRIPTION
The last GitHub action build step to update the manual 'latest' release and tag is unnecessary as Github keeps a latest release reference automatically *and* didn't work in my testing. Removed because its just confusing, IMO :)

Also added a small clarification in the README about the URL to use to point to the module

Aaaand some typo fixes! Yay!