### PR TITLE
Adding Readme and License fields

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
 
     # Create a zip file with all files required by the module to add to the release
-    - run: zip -r ./module.zip module.json LICENSE styles/ scripts/ templates/ languages/
+    - run: zip -r ./module.zip module.json readme.md LICENSE styles/ scripts/ templates/ languages/
 
     # Create a release for this specific version
     - name: Update Release with Files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
 
     # Create a zip file with all files required by the module to add to the release
-    - run: zip -r ./module.zip module.json readme.md LICENSE styles/ scripts/ templates/ languages/
+    - run: zip -r ./module.zip module.json README.md LICENSE styles/ scripts/ templates/ languages/
 
     # Create a release for this specific version
     - name: Update Release with Files

--- a/module.json
+++ b/module.json
@@ -39,6 +39,8 @@
   "url": "This is auto replaced",
   "manifest": "This is auto replaced",
   "download": "This is auto replaced",
+  "license": "LICENSE",
+  "readme": "readme.md",
   "media": [
     {
       "type": "icon",

--- a/module.json
+++ b/module.json
@@ -40,7 +40,7 @@
   "manifest": "This is auto replaced",
   "download": "This is auto replaced",
   "license": "LICENSE",
-  "readme": "readme.md",
+  "readme": "README.md",
   "media": [
     {
       "type": "icon",


### PR DESCRIPTION
Adds the Readme and License fields to the manifest (as relative links to the files in the installed package), and adds the readme into the package zip to allow for this.

While nothing currently consumes these files, they are part of the official spec, and more modules including them will hopefully encourage consumption.  Due to the lack of anything consuming them, there's a certain amount of assumption that just the filename is a valid "path to a license file relative to the root module folder", but AIUI this should be the case.

Relative links were chosen rather than an external link to the repo to ensure that the readme and license are a) the correct ones for the given version, without needing to package them into the release outside of the zip file, and b) available to games played offline, or in the event that the repo is deleted.

One potential improvement would be to render the readme into HTML when packaging (to give something more easily readable to the end user and parseable into Foundry than a markdown file), but I have no idea how to do this.