### PR TITLE
Remove leading `/` to fix issues with users who are using a `ROUTE_PREFIX`

### DIFF
--- a/module.json
+++ b/module.json
@@ -21,13 +21,13 @@
     
   ],
   "esmodules": [
-    "/scripts/module.js"
+    "scripts/module.js"
   ],
   "scripts": [
-    "/scripts/lib/lib.js"
+    "scripts/lib/lib.js"
   ],
   "styles": [
-    "/styles/module.css"
+    "styles/module.css"
   ],
   "languages": [
     {


### PR DESCRIPTION
The leading `/` causes modules to fail for users who use them from a foundry instance configured with a `ROUTE_PREFIX`