### PR TITLE
GitHub are deprecating Node 12 actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Release Creation
 
-on: 
+on:
   release:
     types: [published]
 
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # get part of the tag after the `v`
     - name: Extract tag version number
@@ -18,14 +18,14 @@ jobs:
     # Substitute the Manifest and Download URLs in the module.json
     - name: Substitute Manifest and Download Links For Versioned Ones
       id: sub_manifest_link_version
-      uses: microsoft/variable-substitution@v1
+      uses: cschleiden/replace-tokens@v1
       with:
         files: 'module.json'
       env:
-        version: ${{steps.get_version.outputs.version-without-v}}
-        url: https://github.com/${{github.repository}}
-        manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
-        download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
+        VERSION: ${{steps.get_version.outputs.version-without-v}}
+        URL: https://github.com/${{github.repository}}
+        MANIFEST: https://github.com/${{github.repository}}/releases/latest/download/module.json
+        DOWNLOAD: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
 
     # Create a zip file with all files required by the module to add to the release
     - run: zip -r ./module.zip module.json README.md LICENSE styles/ scripts/ templates/ languages/

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "module",
   "title": "New Module",
   "description": "",
-  "version": "This is auto replaced",
+  "version": "#{VERSION}#",
   "library": "false",
   "manifestPlusVersion": "1.2.0",
   "compatibility": {
@@ -37,9 +37,9 @@
       "path": "languages/en.json"
     }
   ],
-  "url": "This is auto replaced",
-  "manifest": "This is auto replaced",
-  "download": "This is auto replaced",
+  "url": "#{URL}#",
+  "manifest": "#{MANIFEST}#",
+  "download": "#{DOWNLOAD}#",
   "license": "LICENSE",
   "readme": "README.md",
   "media": [


### PR DESCRIPTION
- Updated actions/checkout to v3
- microsoft/variable-substitution is deprecated by microsoft, changed to use cschleiden/replace-tokens instead
- No updated version of battila7/get-version-action available yet (https://github.com/battila7/get-version-action/issues/18)